### PR TITLE
更新所有的"匹"字词编码

### DIFF
--- a/schema/xuma.dict.yaml
+++ b/schema/xuma.dict.yaml
@@ -120348,7 +120348,7 @@ encoder:
 岛国	smne
 这般	yzrq
 近照	rjkd
-马匹	amfv	1850000
+马匹	amgc	1850000
 得宜	skwn
 渊源	ztzg	5210000
 伤痛	tpwd	8070000
@@ -127321,7 +127321,7 @@ encoder:
 忐忑不安	ljgw	2350000
 山洞	mvzm
 体弱多病	tdqw
-匹配	fved	25400000
+匹配	gced	25400000
 替班	jjep	86000
 天花板	fhir	11000000
 右转	hofe
@@ -127865,7 +127865,7 @@ encoder:
 待人接物	sufp	860000
 单刀直入	xdev	631000
 换个	fquk
-单枪匹马	xifa	886000
+单枪匹马	xiga	886000
 棕色	iwqd	16900000
 担惊受怕	fuvu	631000
 发自	aftz
@@ -128656,7 +128656,7 @@ encoder:
 披肝沥胆	fszs
 披星戴月	fkes	402000
 疲于奔命	wgfu	912000
-匹夫有责	fjhe	796000
+匹夫有责	gjhe	796000
 水力	ascl	3400000
 偏听偏信	tott	167000
 品头论足	ozzo	1120000
@@ -130212,7 +130212,7 @@ encoder:
 品评	ooze
 阿塞拜疆	bwpd	1590000
 封神	jjwk
-阿司匹林	bbfi	1370000
+阿司匹林	bbgi	1370000
 屏风	dxqt	6640000
 阿谀奉承	bzeb	376000
 星系	kppa
@@ -130313,7 +130313,7 @@ encoder:
 对质	dire	711000
 奥地利	ujrl	9520000
 慢火	ukxv
-奥林匹克	uifj	6750000
+奥林匹克	uigj	6750000
 疑团	vpni	813000
 奥委会	urue	1770000
 奥运会	ueue	26600000
@@ -136090,7 +136090,7 @@ encoder:
 不衰	gbwo
 五色	gdqd
 水电站	akyl	3050000
-匹敌	fvro
+匹敌	gcro
 手绘	rscu
 水力发电	acak	921000
 水利工程	arir	4760000
@@ -138899,7 +138899,7 @@ encoder:
 熬药	eqhc
 平板	exir	77100000
 打掉	fefl
-奥林匹克运动会	uifu
+奥林匹克运动会	uigu
 奥妙无穷	ucew
 奥斯卡	uhll
 同质	mgre	2460000
@@ -146025,7 +146025,7 @@ encoder:
 王族	evyp
 主子	webz
 史迹	otyz
-布匹	hmfv	1320000
+布匹	hmgc	1320000
 平直	exen	1120000
 试销	zfpn	417000
 交租	ytrn
@@ -154667,7 +154667,7 @@ encoder:
 毛囊	rmeo
 南竹	empk
 脑瓜儿	srve
-匹马单枪	faxi
+匹马单枪	gaxi
 漆包线	zscg
 祈使句	wtso
 石羊	gvxy
@@ -163529,7 +163529,7 @@ encoder:
 大國	fdnf
 島國	umnf
 這般	yzrq
-馬匹	emfv
+馬匹	emgc
 淵源	ztzg
 傷痛	tpwd
 漁業	zqlx
@@ -168034,7 +168034,7 @@ encoder:
 報料	jxxz
 單刀直入	odev
 換個	fqtn
-單槍匹馬	oife
+單槍匹馬	oige
 擔驚受怕	fhvu
 發自	ddtz
 膽大包天	sfsf
@@ -168601,7 +168601,7 @@ encoder:
 蓬頭垢面	hgjg
 披肝瀝膽	fszs
 疲於奔命	wyfu
-匹夫有責	fjhe
+匹夫有責	gjhe
 偏聽偏信	thtt
 品頭論足	ogyo
 平心而論	ergy
@@ -169729,7 +169729,7 @@ encoder:
 凹面鏡	mgvy
 對質	lxrj
 奧地利	ujrl
-奧林匹克	uifj
+奧林匹克	uigj
 疑團	vpng
 奧委會	urug
 奧運會	uqug
@@ -173590,7 +173590,7 @@ encoder:
 雙職工	thig
 水產品	ayoo
 水電站	ajyl
-匹敵	fvyx
+匹敵	gcyx
 手繪	rsau
 水力發電	acdj
 水利廳	arwh
@@ -175528,7 +175528,7 @@ encoder:
 內海	mvzp
 加點	coml
 熬藥	eqhu
-奧林匹克運動會	uifu
+奧林匹克運動會	uigu
 奧妙無窮	ucpw
 奧斯卡	uhll
 同質	mgrj
@@ -185556,7 +185556,7 @@ encoder:
 馬蓮	emhj
 麥秋	iurx
 腦瓜兒	sruv
-匹馬單槍	feoi
+匹馬單槍	geoi
 漆包線	zsau
 物化勞動	ptxr
 相輔而行	ijgs


### PR DESCRIPTION
| 词             | 原编码 | 新编码 |
| -------------- | ------ | ------ |
| 马匹           | amfv   | amgc   |
| 匹配           | fved   | gced   |
| 单枪匹马       | xifa   | xiga   |
| 匹夫有责       | fjhe   | gjhe   |
| 阿司匹林       | bbfi   | bbgi   |
| 奥林匹克       | uifj   | uigj    |
| 匹敌           | fvro   | gcro   |
| 奥林匹克运动会 | uifu   | uigu   |
| 布匹           | hmfv   | hmgc   |
| 匹马单枪       | faxi   | gaxi   |
| 馬匹           | emfv   | emgc   |
| 單槍匹馬       | oife   | oige   |
| 匹夫有責       | fjhe   | gjhe   |
| 奧林匹克       | uifj   | uigj   |
| 匹敵           | fvyx   | gcyx   |
| 奧林匹克運動會 | uifu   | uigu   |
| 匹馬單槍       | feoi   | geoi   |